### PR TITLE
Do not use sudo on localhost for determining Python version

### DIFF
--- a/tasks/users/user_config.yml
+++ b/tasks/users/user_config.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Get local python version
+  become: no
   command: python -V
   delegate_to: localhost
   register: localhost_python


### PR DESCRIPTION
If localhost requests a sudo password, the role will fail. However, this task only determines the local Python version and does not require `become` privileges.