### PR TITLE
Fix regex to lookup version

### DIFF
--- a/tasks/core/apps.yml
+++ b/tasks/core/apps.yml
@@ -55,7 +55,7 @@
           https://apps.nextcloud.com/api/v1/platform/{{
             nextcloud_full_version.stdout_lines[-1]
             | regex_replace(
-                'Nextcloud \b\w*\b ?([0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}) ?.*',
+                '.* ([0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2})$',
                 '\1'
               )
           }}/apps.json


### PR DESCRIPTION
If the Nextcloud instance is renamed, let's say to `mycloud`, the command `php occ -V` actualy prints

```
mycloud 17.0.0
```

Hence, we have to be insensitive to the actual name.