### PR TITLE
Read version string from JSON object of occ status

### DIFF
--- a/tasks/core/apps.yml
+++ b/tasks/core/apps.yml
@@ -51,7 +51,8 @@
 
     - name: Remove non-json text from command output
       set_fact:
-        nextcloud_full_version: "{{ (_result.stdout | from_json)['versionstring'] }}"
+        nextcloud_full_version:
+          "{{ (_result.stdout | from_json)['versionstring'] }}"
 
     - name: Create app json file url
       set_fact:

--- a/tasks/core/apps.yml
+++ b/tasks/core/apps.yml
@@ -41,24 +41,22 @@
 - name: Install external apps
   block:
     - name: Find full nextcloud version
-      command: ./occ -V
+      command: ./occ status  --output=json
       args:
         chdir: "{{ nextcloud_installation_dir }}"
       become: true
       become_user: "{{ nextcloud_file_owner }}"
-      register: nextcloud_full_version
+      register: _output
       changed_when: false
+
+    - name: Remove non-json text from command output
+      set_fact:
+        nextcloud_full_version: "{{ _output.stdout | from_json }}"
 
     - name: Create app json file url
       set_fact:
         nextcloud_app_store_json_url: >-
-          https://apps.nextcloud.com/api/v1/platform/{{
-            nextcloud_full_version.stdout_lines[-1]
-            | regex_replace(
-                '.* ([0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2})$',
-                '\1'
-              )
-          }}/apps.json
+          https://apps.nextcloud.com/api/v1/platform/{{ nextcloud_full_version.versionstring }}/apps.json
       changed_when: false
 
     - name: Download the app json file

--- a/tasks/core/apps.yml
+++ b/tasks/core/apps.yml
@@ -46,17 +46,19 @@
         chdir: "{{ nextcloud_installation_dir }}"
       become: true
       become_user: "{{ nextcloud_file_owner }}"
-      register: _output
+      register: _result
       changed_when: false
 
     - name: Remove non-json text from command output
       set_fact:
-        nextcloud_full_version: "{{ _output.stdout | from_json }}"
+        nextcloud_full_version: "{{ (_result.stdout | from_json)['versionstring'] }}"
 
     - name: Create app json file url
       set_fact:
         nextcloud_app_store_json_url: >-
-          https://apps.nextcloud.com/api/v1/platform/{{ nextcloud_full_version.versionstring }}/apps.json
+          https://apps.nextcloud.com/api/v1/platform/{{
+            nextcloud_full_version
+          }}/apps.json
       changed_when: false
 
     - name: Download the app json file


### PR DESCRIPTION
I have found a way to completely circumvent the regex - we can read the clean `versionstring` from the JSON output of `occ status`.

Is there a reason to not use the `from_json` filter in the other cases where `occ` output is parsed? You added a comment about upgrade notices breaking it - does it only break the filter or also your manual json parsing?