### PR TITLE
Change how preference update is handled

### DIFF
--- a/tasks/core/config.yml
+++ b/tasks/core/config.yml
@@ -22,7 +22,7 @@
 
 - name: Configure nextcloud and apps
   block:
-    - name: Create temp file
+    - name: Create temporary config file
       tempfile:
         suffix: nextcloud
       register: _result
@@ -48,8 +48,8 @@
 
     - meta: flush_handlers
 
-    - name: Delete config file
+    - name: Delete temporary config file
       file:
-        path: /tmp/nextcloud_config_53ab3c4
+        path: "{{ _result.path }}"
         state: absent
   when: _nextcloud_updated_preferences != _nextcloud_old_preferences

--- a/tasks/core/config.yml
+++ b/tasks/core/config.yml
@@ -10,10 +10,14 @@
   become: true
   become_user: "{{ nextcloud_file_owner }}"
 
-- name: Parse global preferences as json
+- name: Parse global preferences as json and merge configurations
   set_fact:
     _nextcloud_old_preferences:
       "{{ _nextcloud_old_preferences.stdout | from_json }}"
+    _nextcloud_updated_preferences: >-
+      {{
+        _nextcloud_old_preferences | combine(nextcloud_config, recursive=True)
+      }}
 
 - name: Configure nextcloud and apps
   block:

--- a/tasks/core/config.yml
+++ b/tasks/core/config.yml
@@ -18,6 +18,7 @@
       {{
         _result.stdout | from_json | combine(nextcloud_config, recursive=True)
       }}
+  no_log: true
 
 - name: Configure nextcloud and apps
   block:

--- a/tasks/core/config.yml
+++ b/tasks/core/config.yml
@@ -49,6 +49,7 @@
     # Check if nextcloud_config is not a subset of the old preferences
     _nextcloud_prefs_need_updating: >-
       {{
-        (nextcloud_config|dict_flatten).items()
-        > (_nextcloud_old_preferences|dict_flatten).items()
+        not ((_nextcloud_old_preferences |
+        combine(nextcloud_config, recursive=True))
+        == _nextcloud_old_preferences)
       }}

--- a/tasks/core/config.yml
+++ b/tasks/core/config.yml
@@ -43,7 +43,7 @@
       register: result
       changed_when: result is success
       notify: nextcloud update htaccess
-      failed_when: (result.stdout|search('invalid entries') or result.rc != 0)
+      failed_when: (result.stdout|lower|search('invalid') or result.rc != 0)
 
     - meta: flush_handlers
 

--- a/tasks/core/config.yml
+++ b/tasks/core/config.yml
@@ -4,7 +4,7 @@
   command: ./occ config:list --private --output=json
   args:
     chdir: "{{ nextcloud_installation_dir }}"
-  register: _nextcloud_old_preferences
+  register: _result
   changed_when: false
   no_log: true
   become: true
@@ -13,10 +13,10 @@
 - name: Parse global preferences as json and merge configurations
   set_fact:
     _nextcloud_old_preferences:
-      "{{ _nextcloud_old_preferences.stdout | from_json }}"
+      "{{ _result.stdout | from_json }}"
     _nextcloud_updated_preferences: >-
       {{
-        _nextcloud_old_preferences | combine(nextcloud_config, recursive=True)
+        _result.stdout | from_json | combine(nextcloud_config, recursive=True)
       }}
 
 - name: Configure nextcloud and apps

--- a/tasks/core/config.yml
+++ b/tasks/core/config.yml
@@ -43,6 +43,7 @@
       register: result
       changed_when: result is success
       notify: nextcloud update htaccess
+      failed_when: (result.stdout|search('invalid entries') or result.rc != 0)
 
     - meta: flush_handlers
 

--- a/tasks/core/config.yml
+++ b/tasks/core/config.yml
@@ -43,7 +43,8 @@
       register: result
       changed_when: result is success
       notify: nextcloud update htaccess
-      failed_when: (result.stdout|lower|search('invalid') or result.rc != 0)
+      failed_when: (not (result.stdout | search('successfully imported'))
+        or result.rc != 0)
 
     - meta: flush_handlers
 

--- a/tasks/core/config.yml
+++ b/tasks/core/config.yml
@@ -43,8 +43,8 @@
       register: result
       changed_when: result is success
       notify: nextcloud update htaccess
-      failed_when: (not (result.stdout | search('successfully imported'))
-        or result.rc != 0)
+      failed_when: (result.stdout is not search('successfully imported')
+        or result is failed)
 
     - meta: flush_handlers
 
@@ -52,4 +52,4 @@
       file:
         path: /tmp/nextcloud_config_53ab3c4
         state: absent
-  when: not (_nextcloud_updated_preferences == _nextcloud_old_preferences)
+  when: _nextcloud_updated_preferences != _nextcloud_old_preferences

--- a/tasks/core/config.yml
+++ b/tasks/core/config.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Get global preferences
-  command: ./occ config:list --output=json
+  command: ./occ config:list --private --output=json
   args:
     chdir: "{{ nextcloud_installation_dir }}"
   register: _nextcloud_old_preferences

--- a/tasks/core/config.yml
+++ b/tasks/core/config.yml
@@ -49,12 +49,4 @@
       file:
         path: /tmp/nextcloud_config_53ab3c4
         state: absent
-  when: _nextcloud_prefs_need_updating | bool
-  vars:
-    # Check if nextcloud_config is not a subset of the old preferences
-    _nextcloud_prefs_need_updating: >-
-      {{
-        not ((_nextcloud_old_preferences |
-        combine(nextcloud_config, recursive=True))
-        == _nextcloud_old_preferences)
-      }}
+  when: not (_nextcloud_updated_preferences == _nextcloud_old_preferences)

--- a/tasks/core/config.yml
+++ b/tasks/core/config.yml
@@ -6,6 +6,7 @@
     chdir: "{{ nextcloud_installation_dir }}"
   register: _nextcloud_old_preferences
   changed_when: false
+  no_log: true
   become: true
   become_user: "{{ nextcloud_file_owner }}"
 


### PR DESCRIPTION
This is an attempt to fix #31.

The new approach is to take the full current preference set, apply the `nextcloud_config` on top and then check if it differs from the current configuration. If yes, we update, if no, we skip.

I now put the merging of the two configs into the condition - if you find it more clear to add a separate

```yaml
- name: Merge local configuration and instance configuration
  set_fact:
    _nextcloud_updated_preferences: "{{ _nextcloud_old_preferences | combine(nextcloud_config, recursive=True) }}"
```

let me know, for me either is fine.

The tests still need to be adapted to check if this works properly, by manual checks worked fine (probably need to catch a case where `nextcloud_config` is empty/ not defined).