### PR TITLE
More options for App handling

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,22 +73,22 @@ nextcloud_urls:
 # will be as the "main" one, for pretty urls, etc.
 
 nextcloud_apps: []
-# Nextcloud apps to be installed, enabled or disabled
+# Nextcloud apps to be installed, removed, enabled or disabled
 # It is a list of hashes. Eg
 #
 # nextcloud_apps:
 #   - name: calendar
-#     version: 1.5.7
 #     state: enabled
 #
 # The action can be defined using the app's state, the following states are supported:
 # - present: The app will be installed, the enabled status will not be changed
-# - absent: The app will be removed
+# - absent: The app will be removed. Only available for external apps.
 # - enabled: The app will be installed if not available yet, and will be enabled
 # - disabled: The app will be installed if not available yet, and will be disabled
 # 
-# If 'version' is not given, then the latest version available for the installed
-# nextcloud version will be installed.
+# Installation and removal is only supported for external apps, apps shipped with
+# Nextcloud can only be enabled or disabled.
+# Currently, always the latest version available from the App Store is installed.
 
 nextcloud_config: {}
 # A yaml array with settings of nextcloud apps.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -101,7 +101,7 @@ nextcloud_config: {}
 # - system: this category contains all basic configuration parameters for the
 #           framework to operate. Its keys are stored in the `config.php` file
 #           of the instance installation's `config` directory.
-# - apps: this categoriy contains settings for the individual apps as well as
+# - apps: this category contains settings for the individual apps as well as
 #         for some core components of the framework (in `core`). These settings
 #         are stored in the database directly and require a correctly
 #         configured system to be accessed.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,6 +72,10 @@ nextcloud_urls:
 # You would normally need only one. If you specify more than one, the first one
 # will be as the "main" one, for pretty urls, etc.
 
+nextcloud_remove_unknown_apps: false
+# Setting to choose whether to remove or keep external apps which have not been
+# installed through this role, but manually or via the Nextcloud admin interface
+
 nextcloud_apps: []
 # Nextcloud apps to be installed, removed, enabled or disabled
 # It is a list of hashes. Eg
@@ -90,7 +94,9 @@ nextcloud_apps: []
 #   disabled
 #
 # Installation and removal is only supported for external apps, apps shipped
-# with Nextcloud can only be enabled or disabled.
+# with Nextcloud can only be enabled or disabled. By default, only apps with
+# the explicit state `absent` are removed, to remove all apps missing from the
+# list, set `nextcloud_remove_unknown_apps: true`.
 # Currently, always the latest version available from the App Store is
 # installed.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,18 +73,36 @@ nextcloud_urls:
 # will be as the "main" one, for pretty urls, etc.
 
 nextcloud_apps: []
-# The ansible apps to install and enable
+# Nextcloud apps to be installed, enabled or disabled
 # It is a list of hashes. Eg
 #
 # nextcloud_apps:
 #   - name: calendar
 #     version: 1.5.7
+#     state: enabled
 #
+# The action can be defined using the app's state, the following states are supported:
+# - present: The app will be installed, the enabled status will not be changed
+# - absent: The app will be removed
+# - enabled: The app will be installed if not available yet, and will be enabled
+# - disabled: The app will be installed if not available yet, and will be disabled
+# 
 # If 'version' is not given, then the latest version available for the installed
 # nextcloud version will be installed.
 
 nextcloud_config: {}
-# A yaml array with settings of nextcloud apps. For instance:
+# A yaml array with settings of nextcloud apps.
+#
+# Nextcloud organizes its configuration in two categories:
+# - system: this category contains all basic configuration parameters for the
+#           framework to operate. Its keys are stored in the `config.php` file
+#           of the instance installation's `config` directory.
+# - apps: this categoriy contains settings for the individual apps as well as
+#         for some core components of the framework (in `core`). These settings
+#         are stored in the database directly and require a correctly
+#         configured system to be accessed.
+#
+# For instance:
 # ```
 # nextcloud_config:
 #   apps:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,15 +80,19 @@ nextcloud_apps: []
 #   - name: calendar
 #     state: enabled
 #
-# The action can be defined using the app's state, the following states are supported:
+# The action can be defined using the app's state, the following states are
+# supported:
 # - present: The app will be installed, the enabled status will not be changed
 # - absent: The app will be removed. Only available for external apps.
-# - enabled: The app will be installed if not available yet, and will be enabled
-# - disabled: The app will be installed if not available yet, and will be disabled
-# 
-# Installation and removal is only supported for external apps, apps shipped with
-# Nextcloud can only be enabled or disabled.
-# Currently, always the latest version available from the App Store is installed.
+# - enabled: The app will be installed if not available yet, and will be
+#   enabled
+# - disabled: The app will be installed if not available yet, and will be
+#   disabled
+#
+# Installation and removal is only supported for external apps, apps shipped
+# with Nextcloud can only be enabled or disabled.
+# Currently, always the latest version available from the App Store is
+# installed.
 
 nextcloud_config: {}
 # A yaml array with settings of nextcloud apps.

--- a/tasks/core/apps.yml
+++ b/tasks/core/apps.yml
@@ -1,27 +1,7 @@
 ---
 
-- name: Read builtin apps
-  command: ./occ app:list --shipped=true --output=json
-  args:
-    chdir: "{{ nextcloud_installation_dir }}"
-  register: nextcloud_shipped_apps
-  become: true
-  become_user: "{{ nextcloud_file_owner }}"
-  changed_when: false
-
-# There might be a notice for required updates. This notice will break json
-# parsing.
-- name: Remove non-json text from command output
-  set_fact:
-    nextcloud_shipped_apps: >-
-      {{
-        nextcloud_shipped_apps.stdout[
-          (nextcloud_shipped_apps.stdout.find('{')):
-        ]
-      }}
-
-- name: Read all installed apps
-  command: ./occ app:list --output=json
+- name: Read installed external apps
+  command: ./occ app:list --shipped=false --output=json
   args:
     chdir: "{{ nextcloud_installation_dir }}"
   become: true
@@ -39,136 +19,30 @@
       }}
 
 - name: Install external apps
-  block:
-    - name: Find full nextcloud version
-      command: ./occ status  --output=json
-      args:
-        chdir: "{{ nextcloud_installation_dir }}"
-      become: true
-      become_user: "{{ nextcloud_file_owner }}"
-      register: _result
-      changed_when: false
+  command: php occ app:install "{{ item.name }}"
+  with_items: "{{ nextcloud_apps }}"
+  become_user: "{{ nextcloud_file_owner }}"
+  args:
+    chdir: "{{ nextcloud_installation_dir }}"
+  register: result
+  failed_when: result.stdout is not search('installed') or result is failed
+  changed_when: result is not failed
+  when: >-
+    nextcloud_version >= 13 and
+    item.name not in (nextcloud_installed_apps.enabled
+    | combine(nextcloud_installed_apps.disabled))
 
-    - name: Remove non-json text from command output
-      set_fact:
-        nextcloud_full_version:
-          "{{ (_result.stdout | from_json)['versionstring'] }}"
-
-    - name: Create app json file url
-      set_fact:
-        nextcloud_app_store_json_url: >-
-          https://apps.nextcloud.com/api/v1/platform/{{
-            nextcloud_full_version
-          }}/apps.json
-      changed_when: false
-
-    - name: Download the app json file
-      get_url:
-        url: "{{ nextcloud_app_store_json_url }}"
-        dest: /tmp
-      register: result
-      until: result is success
-
-    - name: Read the app json file
-      command: cat /tmp/apps.json
-      register: nextcloud_app_store_json
-      changed_when: false
-
-    - name: Parse the app json file
-      set_fact:
-        nextcloud_app_store_json:
-          "{{ nextcloud_app_store_json.stdout | from_json }}"
-      changed_when: false
-
-    - name: Download apps
-      unarchive:
-        src: >-
-          {%- set tmp=(
-            nextcloud_app_store_json
-            | selectattr('id', 'equalto', item.name)
-            | map(attribute='releases')
-            | first
-            | list
-            ) -%}
-          {% if 'version' in item %}
-            {% set tmp=(
-                tmp
-                | selectattr('version', 'equalto', item.version)
-                | list)
-            %}
-          {% endif %}
-          {{ (tmp | first).download }}
-        dest: "{{ nextcloud_installation_dir }}/apps"
-        remote_src: true
-        mode: u=rwX,g=rX,o=rX
-      with_items: "{{ nextcloud_apps }}"
-      notify:
-        - set app files permissions
-      when: download_app | bool
-      vars:
-        download_app: >-
-          {#- There are three checks here: -#}
-          {#- 1. The app does not exist in the nextcloud installation -#}
-          {#- 2. The version for an app is different to the one installed -#}
-          {#- 3. The app was specified without a version, meaning the latest
-                 version available should be downloaded. So, the version from
-                 the appstore is checked against the local version -#}
-          {{
-            (
-              item.name not in
-                nextcloud_shipped_apps.enabled
-                | combine(nextcloud_shipped_apps.disabled)
-                | combine(nextcloud_shipped_apps.enabled)
-                | combine(nextcloud_shipped_apps.disabled)
-            )
-            or
-            (
-              item.name in
-                nextcloud_installed_apps.enabled
-                | combine(nextcloud_installed_apps.disabled)
-              and
-              'version' in item
-              and
-              item.version | default('unset') !=
-                (
-                  nextcloud_installed_apps.enabled
-                  | combine(nextcloud_installed_apps.disabled)
-                )[item.name]
-            )
-            or
-            (
-              (
-                nextcloud_app_store_json
-                | selectattr('id', 'equalto', item.name)
-                | map(attribute='releases')
-                | first
-                | list
-              )[0].version
-              !=
-              (
-                (
-                  nextcloud_installed_apps.enabled
-                  | combine(nextcloud_installed_apps.disabled)
-                ) [item.name]
-              )
-            )
-          }}
-
-  # Is this really useful? If occ supports app:update, then it makes sense
-  # - name: Install external apps
-  #   command: php occ app:install "{{ item.name }}"
-  #   with_items: "{{ nextcloud_apps }}"
-  #   become_user: "{{ nextcloud_file_owner }}"
-  #   args:
-  #     chdir: "{{ nextcloud_installation_dir }}"
-  #   register: result
-  #   failed_when: not (result.stdout
-  #     | search('already installed') or result.rc == 0)
-  #   changed_when: result.rc == 0
-  #   when: >-
-  #     nextcloud_version >= 13 and
-  #     item.name not in (nextcloud_installed_apps.enabled
-  #       | combine(nextcloud_installed_apps.disabled))
+- name: Update external apps
+  command: php occ app:update "{{ item }}"
+  with_items: "{{ (nextcloud_installed_apps.enabled
+    | combine(nextcloud_installed_apps.disabled)) }}"
+  become_user: "{{ nextcloud_file_owner }}"
+  args:
+    chdir: "{{ nextcloud_installation_dir }}"
+  register: result
+  failed_when: result.stdout is search('not installed') or result is failed
+  changed_when: result.stdout is search('updated') and result is not failed
+  when: nextcloud_version >= 13
 
 - name: Enable apps
   command: ./occ app:enable "{{ item.name }}"
@@ -178,3 +52,21 @@
   become_user: "{{ nextcloud_file_owner }}"
   with_items: "{{ nextcloud_apps }}"
   when: item.name not in nextcloud_installed_apps.enabled
+
+- name: Re-read installed external apps
+  command: ./occ app:list --shipped=false --output=json
+  args:
+    chdir: "{{ nextcloud_installation_dir }}"
+  become: true
+  become_user: "{{ nextcloud_file_owner }}"
+  register: nextcloud_installed_apps
+  changed_when: false
+
+- name: Remove non-json text from command output
+  set_fact:
+    nextcloud_installed_apps: >-
+      {{
+        nextcloud_installed_apps.stdout[
+          (nextcloud_installed_apps.stdout.find('{')):
+        ]
+      }}

--- a/tasks/core/apps.yml
+++ b/tasks/core/apps.yml
@@ -38,16 +38,9 @@
         ]
       }}
 
-- name: Set default package state
-  set_fact:
-    _default_state: >-
-      {% if nextcloud_remove_unknown_apps %}absent{% else %}enabled{% endif %}
-
-# Remove all apps from the list of external apps which
-# - is not in the configured list of apps
-#   (only if nextcloud_remove_unknown_apps is set to true)
-# - is in the configured list of apps but have their state set to "absent"
-- name: Remove external apps
+# Remove all apps from the list of external apps which are not in the
+# configured list of apps, if nextcloud_remove_unknown_apps is set to true
+- name: Remove unknown external apps
   command: php occ app:remove "{{ item }}"
   with_items: "{{ (nextcloud_installed_apps.enabled |
     combine(nextcloud_installed_apps.disabled)) }}"
@@ -58,9 +51,25 @@
   register: result
   failed_when: result.stdout is not search('removed') or result is failed
   changed_when: result is not failed
-  when: >-
-    ((nextcloud_apps | selectattr('name', 'search', item) | list | first
-    | default({'state':_default_state})).state | default('enabled')) == 'absent'
+  when:
+    - nextcloud_remove_unknown_apps
+    - not (nextcloud_apps | selectattr('name', 'search', item) | list)
+
+# Remove all apps which have their state set to "absent"
+- name: Remove external apps
+  command: php occ app:remove "{{ item.name }}"
+  with_items: "{{ nextcloud_apps }}"
+  become: true
+  become_user: "{{ nextcloud_file_owner }}"
+  args:
+    chdir: "{{ nextcloud_installation_dir }}"
+  register: result
+  failed_when: result.stdout is not search('removed') or result is failed
+  changed_when: result is not failed
+  when:
+    - item.name in (nextcloud_installed_apps.enabled
+      | combine(nextcloud_installed_apps.disabled))
+    - item.state | default('enabled') == 'absent'
 
 # Install all apps from the configured list which
 # - are external apps (not in the shipped apps list) and

--- a/tasks/core/apps.yml
+++ b/tasks/core/apps.yml
@@ -134,4 +134,5 @@
   when: >-
     (item.state | default('enabled')) == 'disabled' and
     item.name not in
-    (nextcloud_installed_apps.disabled | combine(nextcloud_shipped_apps.disabled))
+    (nextcloud_installed_apps.disabled
+    | combine(nextcloud_shipped_apps.disabled))

--- a/tasks/core/apps.yml
+++ b/tasks/core/apps.yml
@@ -70,12 +70,12 @@
   register: result
   failed_when: result.stdout is not search('installed') or result is failed
   changed_when: result is not failed
-  when: >-
-    item.name not in (nextcloud_shipped_apps.enabled
-    | combine(nextcloud_shipped_apps.disabled)) and
-    item.name not in (nextcloud_installed_apps.enabled
-    | combine(nextcloud_installed_apps.disabled)) and
-    (item.state | default('enabled') != 'absent')
+  when:
+    - item.name not in (nextcloud_shipped_apps.enabled
+      | combine(nextcloud_shipped_apps.disabled))
+    - item.name not in (nextcloud_installed_apps.enabled
+      | combine(nextcloud_installed_apps.disabled))
+    - item.state | default('enabled') != 'absent'
 
 # Update list of available apps after installation and removal:
 - name: Re-read installed external apps
@@ -119,10 +119,10 @@
   become: true
   become_user: "{{ nextcloud_file_owner }}"
   with_items: "{{ nextcloud_apps }}"
-  when: >-
-    (item.state | default('enabled')) == 'enabled' and
-    item.name not in
-    (nextcloud_installed_apps.enabled | combine(nextcloud_shipped_apps.enabled))
+  when:
+    - (item.state | default('enabled')) == 'enabled'
+    - item.name not in (nextcloud_installed_apps.enabled
+      | combine(nextcloud_shipped_apps.enabled))
 
 # Disable all apps from the configured list which
 # - are not yet disabled and
@@ -134,8 +134,7 @@
   become: true
   become_user: "{{ nextcloud_file_owner }}"
   with_items: "{{ nextcloud_apps }}"
-  when: >-
-    (item.state | default('enabled')) == 'disabled' and
-    item.name not in
-    (nextcloud_installed_apps.disabled
-    | combine(nextcloud_shipped_apps.disabled))
+  when:
+    - (item.state | default('enabled')) == 'disabled'
+    - item.name not in (nextcloud_installed_apps.disabled
+      | combine(nextcloud_shipped_apps.disabled))

--- a/tasks/core/apps.yml
+++ b/tasks/core/apps.yml
@@ -45,6 +45,7 @@
   command: php occ app:remove "{{ item }}"
   with_items: "{{ (nextcloud_installed_apps.enabled |
     combine(nextcloud_installed_apps.disabled)) }}"
+  become: true
   become_user: "{{ nextcloud_file_owner }}"
   args:
     chdir: "{{ nextcloud_installation_dir }}"
@@ -62,6 +63,7 @@
 - name: Install external apps
   command: php occ app:install "{{ item.name }}"
   with_items: "{{ nextcloud_apps }}"
+  become: true
   become_user: "{{ nextcloud_file_owner }}"
   args:
     chdir: "{{ nextcloud_installation_dir }}"
@@ -99,6 +101,7 @@
   command: php occ app:update "{{ item }}"
   with_items: "{{ (nextcloud_installed_apps.enabled
     | combine(nextcloud_installed_apps.disabled)) }}"
+  become: true
   become_user: "{{ nextcloud_file_owner }}"
   args:
     chdir: "{{ nextcloud_installation_dir }}"

--- a/tasks/core/apps.yml
+++ b/tasks/core/apps.yml
@@ -1,5 +1,25 @@
 ---
 
+# Read all apps shipped by Nextcloud itself
+- name: Read shipped apps
+  command: ./occ app:list --shipped=true --output=json
+  args:
+    chdir: "{{ nextcloud_installation_dir }}"
+  become: true
+  become_user: "{{ nextcloud_file_owner }}"
+  register: nextcloud_shipped_apps
+  changed_when: false
+
+- name: Remove non-json text from command output
+  set_fact:
+    nextcloud_shipped_apps: >-
+      {{
+        nextcloud_shipped_apps.stdout[
+          (nextcloud_shipped_apps.stdout.find('{')):
+        ]
+      }}
+
+# Read all external apps which have been installed by in addition
 - name: Read installed external apps
   command: ./occ app:list --shipped=false --output=json
   args:

--- a/tasks/core/apps.yml
+++ b/tasks/core/apps.yml
@@ -38,6 +38,23 @@
         ]
       }}
 
+# Remove all apps from the list of external apps which
+# - is not in the configured list of apps
+# - is in the configured list of apps but have their state set to "absent"
+- name: Remove external apps
+  command: php occ app:remove "{{ item }}"
+  with_items: "{{ (nextcloud_installed_apps.enabled |
+    combine(nextcloud_installed_apps.disabled)) }}"
+  become_user: "{{ nextcloud_file_owner }}"
+  args:
+    chdir: "{{ nextcloud_installation_dir }}"
+  register: result
+  failed_when: result.stdout is not search('removed') or result is failed
+  changed_when: result is not failed
+  when: >-
+    ((nextcloud_apps | selectattr('name', 'search', item) | list | first
+    | default({'state':'absent'})).state | default('enabled')) == 'absent'
+
 # Install all apps from the configured list which
 # - are external apps (not in the shipped apps list) and
 # - are not yet installed (not in the installed apps list) and
@@ -101,7 +118,8 @@
   with_items: "{{ nextcloud_apps }}"
   when: >-
     (item.state | default('enabled')) == 'enabled' and
-    item.name not in (nextcloud_installed_apps.enabled | combine(nextcloud_shipped_apps.enabled))
+    item.name not in
+    (nextcloud_installed_apps.enabled | combine(nextcloud_shipped_apps.enabled))
 
 # Disable all apps from the configured list which
 # - are not yet disabled and
@@ -115,4 +133,5 @@
   with_items: "{{ nextcloud_apps }}"
   when: >-
     (item.state | default('enabled')) == 'disabled' and
-    item.name not in (nextcloud_installed_apps.disabled | combine(nextcloud_shipped_apps.disabled))
+    item.name not in
+    (nextcloud_installed_apps.disabled | combine(nextcloud_shipped_apps.disabled))

--- a/tasks/core/apps.yml
+++ b/tasks/core/apps.yml
@@ -38,8 +38,14 @@
         ]
       }}
 
+- name: Set default package state
+  set_fact:
+    _default_state: >-
+      {% if nextcloud_remove_unknown_apps %}absent{% else %}enabled{% endif %}
+
 # Remove all apps from the list of external apps which
 # - is not in the configured list of apps
+#   (only if nextcloud_remove_unknown_apps is set to true)
 # - is in the configured list of apps but have their state set to "absent"
 - name: Remove external apps
   command: php occ app:remove "{{ item }}"
@@ -54,7 +60,7 @@
   changed_when: result is not failed
   when: >-
     ((nextcloud_apps | selectattr('name', 'search', item) | list | first
-    | default({'state':'absent'})).state | default('enabled')) == 'absent'
+    | default({'state':_default_state})).state | default('enabled')) == 'absent'
 
 # Install all apps from the configured list which
 # - are external apps (not in the shipped apps list) and

--- a/tasks/core/apps.yml
+++ b/tasks/core/apps.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Read builtin apps
-  command: ./occ app:list --shipped=SHIPPED --output=json
+  command: ./occ app:list --shipped=true --output=json
   args:
     chdir: "{{ nextcloud_installation_dir }}"
   register: nextcloud_shipped_apps

--- a/tasks/core/apps.yml
+++ b/tasks/core/apps.yml
@@ -38,6 +38,10 @@
         ]
       }}
 
+# Install all apps from the configured list which
+# - are external apps (not in the shipped apps list) and
+# - are not yet installed (not in the installed apps list) and
+# - have their state not set to "absent"
 - name: Install external apps
   command: php occ app:install "{{ item.name }}"
   with_items: "{{ nextcloud_apps }}"
@@ -48,31 +52,13 @@
   failed_when: result.stdout is not search('installed') or result is failed
   changed_when: result is not failed
   when: >-
-    nextcloud_version >= 13 and
+    item.name not in (nextcloud_shipped_apps.enabled
+    | combine(nextcloud_shipped_apps.disabled)) and
     item.name not in (nextcloud_installed_apps.enabled
-    | combine(nextcloud_installed_apps.disabled))
+    | combine(nextcloud_installed_apps.disabled)) and
+    (item.state | default('enabled') != 'absent')
 
-- name: Update external apps
-  command: php occ app:update "{{ item }}"
-  with_items: "{{ (nextcloud_installed_apps.enabled
-    | combine(nextcloud_installed_apps.disabled)) }}"
-  become_user: "{{ nextcloud_file_owner }}"
-  args:
-    chdir: "{{ nextcloud_installation_dir }}"
-  register: result
-  failed_when: result.stdout is search('not installed') or result is failed
-  changed_when: result.stdout is search('updated') and result is not failed
-  when: nextcloud_version >= 13
-
-- name: Enable apps
-  command: ./occ app:enable "{{ item.name }}"
-  args:
-    chdir: "{{ nextcloud_installation_dir }}"
-  become: true
-  become_user: "{{ nextcloud_file_owner }}"
-  with_items: "{{ nextcloud_apps }}"
-  when: item.name not in nextcloud_installed_apps.enabled
-
+# Update list of available apps after installation and removal:
 - name: Re-read installed external apps
   command: ./occ app:list --shipped=false --output=json
   args:
@@ -90,3 +76,43 @@
           (nextcloud_installed_apps.stdout.find('{')):
         ]
       }}
+
+# Check and update all external apps
+- name: Update external apps
+  command: php occ app:update "{{ item }}"
+  with_items: "{{ (nextcloud_installed_apps.enabled
+    | combine(nextcloud_installed_apps.disabled)) }}"
+  become_user: "{{ nextcloud_file_owner }}"
+  args:
+    chdir: "{{ nextcloud_installation_dir }}"
+  register: result
+  failed_when: result.stdout is search('not installed') or result is failed
+  changed_when: result.stdout is search('updated') and result is not failed
+
+# Enable all apps from the configured list which
+# - are not yet enabled and
+# - have their state set to "enabled"
+- name: Enable apps
+  command: ./occ app:enable "{{ item.name }}"
+  args:
+    chdir: "{{ nextcloud_installation_dir }}"
+  become: true
+  become_user: "{{ nextcloud_file_owner }}"
+  with_items: "{{ nextcloud_apps }}"
+  when: >-
+    (item.state | default('enabled')) == 'enabled' and
+    item.name not in (nextcloud_installed_apps.enabled | combine(nextcloud_shipped_apps.enabled))
+
+# Disable all apps from the configured list which
+# - are not yet disabled and
+# - have their state set to "disabled"
+- name: Disable apps
+  command: ./occ app:disable "{{ item.name }}"
+  args:
+    chdir: "{{ nextcloud_installation_dir }}"
+  become: true
+  become_user: "{{ nextcloud_file_owner }}"
+  with_items: "{{ nextcloud_apps }}"
+  when: >-
+    (item.state | default('enabled')) == 'disabled' and
+    item.name not in (nextcloud_installed_apps.disabled | combine(nextcloud_shipped_apps.disabled))


### PR DESCRIPTION
This PR extends the functionality of the apps handling in this role. I have found that the manual installation procedure is too clumsy and I dropped it in favor of using `occ app:<...>`. This means (in contrast to what has been discussed in #8) it is not possible anymore to specify a version for an app to be installed. But we can now:

* install apps: just add them to the `nextcloud_apps` list.
* remove apps: either remove them from the `nextcloud_apps` list or set
    ```yaml
    nextcloud_apps:
      - name: bookmarks
        state: absent
    ```
* Disable or enable apps (including shipped system apps):
    ```yaml
    nextcloud_apps:
      - name: survey_client
        state: disabled
      - name: admin_audit
        state: enabled
    ```

The list of installed apps is refreshed after all install/removal happened and the remaining apps are updated to their latest available versions.