### PR TITLE
Make Integrity Checks of Core and Apps Optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,6 +72,15 @@ nextcloud_urls:
 # You would normally need only one. If you specify more than one, the first one
 # will be as the "main" one, for pretty urls, etc.
 
+nextcloud_check_integrity_core: true
+# Setting to choose whether to run the code integrity check on the Nextcloud
+# core files.
+
+nextcloud_check_integrity_apps: true
+# Setting to choose whether to run the code integrity check for each of the
+# installed apps. beware that many apps don't ship a code signature and this
+# check might result in an error in the Nextcloud log.
+
 nextcloud_remove_unknown_apps: false
 # Setting to choose whether to remove or keep external apps which have not been
 # installed through this role, but manually or via the Nextcloud admin interface

--- a/tasks/core/integrity.yml
+++ b/tasks/core/integrity.yml
@@ -36,26 +36,30 @@
       set_fact:
         nextcloud_extra_files: >-
           [
-            {%- for result in nextcloud_integrity_apps.results -%}
-              {%- set appname=(result.cmd[3]) -%}
-              {%- set files=(result.stdout_lines[-1] | from_json) -%}
-              {%- if files is mapping and 'EXTRA_FILE' in files -%}
-                "{{ []
-                  | zip_longest(
-                    files['EXTRA_FILE'].keys(),
-                    fillvalue=("apps/" ~ appname)
+            {%- if nextcloud_check_integrity_apps -%}
+              {%- for result in nextcloud_integrity_apps.results -%}
+                {%- set appname=(result.cmd[3]) -%}
+                {%- set files=(result.stdout_lines[-1] | from_json) -%}
+                {%- if files is mapping and 'EXTRA_FILE' in files -%}
+                  "{{ []
+                    | zip_longest(
+                      files['EXTRA_FILE'].keys(),
+                      fillvalue=("apps/" ~ appname)
+                    )
+                    | map('join', '/')
+                    | list
+                    | join('","') }}"
+                    ,
+                {%- endif -%}
+              {%- endfor -%}
+            {%- endif -%}
+            {%- if nextcloud_check_integrity_apps -%}
+              {%- set files=(
+                    nextcloud_integrity_core.stdout_lines[-1]
+                    | from_json
                   )
-                  | map('join', '/')
-                  | list
-                  | join('","') }}"
-                  ,
-              {%- endif -%}
-            {%- endfor -%}
-            {%- set files=(
-                  nextcloud_integrity_core.stdout_lines[-1]
-                  | from_json
-                )
-            -%}
+              -%}
+            {%- endif -%}
             {%- if files is mapping and 'EXTRA_FILE' in files -%}
               '{{ files["EXTRA_FILE"].keys() | join("','") }}'
             {%- endif -%}

--- a/tasks/core/integrity.yml
+++ b/tasks/core/integrity.yml
@@ -11,6 +11,7 @@
       become_user: "{{ nextcloud_file_owner }}"
       failed_when: false
       changed_when: false
+      when: nextcloud_check_integrity_core
 
     - name: Run integrity check for apps
       command: "./occ integrity:check-app {{ item }} --output=json"
@@ -29,6 +30,7 @@
       failed_when: false
       become: true
       become_user: "{{ nextcloud_file_owner }}"
+      when: nextcloud_check_integrity_apps
 
     - name: Extract extra files that need deletion
       set_fact:
@@ -58,6 +60,7 @@
               '{{ files["EXTRA_FILE"].keys() | join("','") }}'
             {%- endif -%}
           ]
+  when: nextcloud_check_integrity_core or nextcloud_check_integrity_apps
 
 - name: Delete extra files
   block:
@@ -77,6 +80,7 @@
       become_user: "{{ nextcloud_file_owner }}"
       failed_when: false
       changed_when: false
+      when: nextcloud_check_integrity_core
 
     - name: Re-run integrity check for apps to update integrity results
       command: "./occ integrity:check-app {{ item }} --output=json"
@@ -94,4 +98,5 @@
       failed_when: false
       become: true
       become_user: "{{ nextcloud_file_owner }}"
+      when: nextcloud_check_integrity_apps
   when: nextcloud_extra_files | length > 0


### PR DESCRIPTION
This MR adds two configuration keys `nextcloud_check_integrity_core` and `nextcloud_check_integrity_apps` to allow switching code integrity checks for apps and core on or off.

This is sort of a workaround for #8 - I for now just switch integrity checks for apps off.